### PR TITLE
Adjusted `moveEnemyTowardTarget` to accept type: `Cell[]`

### DIFF
--- a/src/enemyMovement.ts
+++ b/src/enemyMovement.ts
@@ -1,23 +1,42 @@
-import type { Enemy, PathNode } from "./type";
+import type { Enemy, Cell } from "./type";
 
 
-export function moveEnemyTowardTarget(enemy: Enemy, longestPath: PathNode[]): void {
+export function moveEnemyTowardTarget(enemy: Enemy, finalPath: Cell[]): void {
   const target = enemy.to
-  const index = longestPath.findIndex(node => node.x === target.x && node.y === target.y)
+  const index = finalPath.findIndex(node => node.x === target.x && node.y === target.y)
+  console.log('Current index:', index, 'Target:', target, 'Next target:', finalPath[index + 1])
+
+  if (!target)
+    throw new Error('Enemy sprite should be destroyed')
+
+  if (!target.x || !target.y) {
+    throw new Error('Enemy has no valid target cell')
+  }
+
+  // add check for 
 
   if (target) {
-    if (enemy.currentPosition.x < target.x) {
-      enemy.currentPosition.x += 1
+    // Move right
+    if (enemy.currentPosition.x < target.x) enemy.currentPosition.x += 1
 
-    }
+    // Move down
+    if (enemy.currentPosition.y < target.y) enemy.currentPosition.y += 1
 
-    if (enemy.currentPosition.y < target.y) {
-      enemy.currentPosition.y += 1
+    // Move left
+    if (enemy.currentPosition.y > target.x) enemy.currentPosition.x -= 1
 
-    }
+    // Move up
+    if (enemy.currentPosition.y > target.y) enemy.currentPosition.y -= 1
+
+
     // update to next waypoint
     if (enemy.currentPosition.x == target.x && enemy.currentPosition.y == target.y) {
-      enemy.to = longestPath[index + 1]
+      if (index + 1 < finalPath.length) {
+        enemy.to = finalPath[index + 1]
+      } else {
+        enemy.to = null
+      }
     }
+
   }
 }

--- a/src/gameEngine/gameLogic.ts
+++ b/src/gameEngine/gameLogic.ts
@@ -1,5 +1,4 @@
-import type { Container } from "pixi.js";
-import type { GameState, Grid, Piece, PlacedPiece } from "../type";
+import type { Grid, Piece } from "../type";
 
 export function canPlacePiece(grid: Grid, piece: Piece, topLeftX: number, topLeftY: number): boolean {
     const transformed = piece.shape;
@@ -20,6 +19,6 @@ export function canPlacePiece(grid: Grid, piece: Piece, topLeftX: number, topLef
     return true;
 }
 
-export function placePiece(grid:Grid, piece:Piece, topLeftX:number, topLeftY:number):boolean {
-  const
+export function placePiece(grid: Grid, piece: Piece, topLeftX: number, topLeftY: number): boolean {
+
 }

--- a/src/gameStateMachine.ts
+++ b/src/gameStateMachine.ts
@@ -5,20 +5,31 @@ import {
   type GameState,
   createEmptyGrid,
   initialPlayer,
-  type PathNode,
+  type Cell,
 } from "./type";
 
-const mockPath: PathNode[] = [
-  { id: "node0", x: 3, y: 0 },
-  { id: "node1", x: 4, y: 3 },
-  { id: "node2", x: 5, y: 3 },
-  { id: "node3", x: 6, y: 3 },
-  { id: "node4", x: 6, y: 4 },
-  { id: "node5", x: 6, y: 5 },
-  { id: "node6", x: 6, y: 6 },
-  { id: "node7", x: 7, y: 6 },
-  { id: "node8", x: 8, y: 6 },
-  { id: "node9", x: 3, y: 9 },
+// export type Cell = {
+//   x: number | null; //col horizontal
+//   y: number | null; //row vertical
+//   // Grid[y][x] refers to the correct cell
+//   type: CellType;
+//   selectionState?: CellSelectionState; //used during final path selection
+//   occupiedBy?: string;
+//   terrain?: string //potential different effects later
+// }
+
+// this will need to be translated somehow to work w/ path logic of Type Cell
+const mockPath: Cell[] = [
+  { type: "path", x: 3, y: 0 },
+  { type: "path", x: 4, y: 3 },
+  { type: "path", x: 5, y: 3 },
+  { type: "path", x: 6, y: 4 },
+  { type: "path", x: 6, y: 5 },
+  { type: "path", x: 6, y: 3 },
+  { type: "path", x: 6, y: 6 },
+  { type: "path", x: 7, y: 6 },
+  { type: "path", x: 8, y: 6 },
+  { type: "path", x: 3, y: 9 },
 ];
 
 export const initialGameState: GameState = {
@@ -67,8 +78,12 @@ export function loop(gameState: GameState): GameState {
     const enemyCellRow = enemy.currentPosition.y
 
     moveEnemyTowardTarget(newGameState.enemies[0], mockPath)
-    //console.log('Enemy moved to cell:', enemyCellCol, enemyCellRow)
+    console.log('Enemy moved to cell:', enemyCellCol, enemyCellRow)
   }
+
+  // filter enemies who've reached the end of the player's path from the newGameState
+  // this gets taken care of in `renderer.tsx` updateEnemies()
+  newGameState.enemies = newGameState.enemies.filter(enemy => enemy.to !== null)
 
   return newGameState
 }

--- a/src/pixi/renderer.tsx
+++ b/src/pixi/renderer.tsx
@@ -86,14 +86,14 @@ export async function initApp(canvas: HTMLCanvasElement): Promise<Application> {
     })
   })
 
-  
+
 
   return app
 }
 
 // TODO: I am suspicious of initializing the application on every render.
 // PROBABLY I should have some initialization which occurs separately from every render.
-export function render(app: Application, gameState: GameState, board:Container) {
+export function render(app: Application, gameState: GameState, board: Container) {
   // render the board
   renderBoard(app, gameState)
 
@@ -140,5 +140,21 @@ export function updateEnemies(app: Application, gameState: GameState) {
     sprite.y = enemy.currentPosition.y * 60
   })
 
+  // compares sprite cache to what's in current gameState
+  const currentEnemyIds = new Set(gameState.enemies.map(e => e.id))
+
+  enemySprites.forEach((sprite, id) => {
+    // if enemy sprite no longer in gameState
+    if (!currentEnemyIds.has(id)) {
+      sprite.destroy()  // Clean up GPU resources
+      enemySprites.delete(id)  // remove from Map
+    }
+  })
+
   return app
 }
+
+// write export updateSelectionState() that checks all path cells within gameState grid if changed render different color
+// look in gameState for all cells that have: selected = green, highlighted path = yellow, 
+// so we can update game board 
+// if neither the cell goes back to what it was before empty = grey, path = brown

--- a/src/type.ts
+++ b/src/type.ts
@@ -65,7 +65,7 @@ export type Enemy = {
     maxHealth: number;
     armor?: number;
     speed: number;
-    to: PathNode;
+    to: Cell | null;  // updated to Cell type to account for pathfinding | updated to null to account for de-spawning enemies 
     currentPosition: { x: number, y: number }
     gold: number;
 }
@@ -114,19 +114,19 @@ export function createEmptyGrid(): Grid {
     );
 }
 
-export function createSpawn(x: number, y: number) : Cell {
-    const spawn : Cell = {
+export function createSpawn(x: number, y: number): Cell {
+    const spawn: Cell = {
         x,
-        y, 
+        y,
         type: 'spawn',
     }
     return spawn;
 }
 
-export function createExit(x: number, y: number) : Cell {
-    const spawn : Cell = {
+export function createExit(x: number, y: number): Cell {
+    const spawn: Cell = {
         x,
-        y, 
+        y,
         type: 'exit',
     }
     return spawn;
@@ -137,7 +137,7 @@ export const initialGameState: GameState = {
     phase: 'Build',
     grid: createEmptyGrid(),
     spawn: createSpawn(0, 0),
-    exit: createExit(9,9),
+    exit: createExit(9, 9),
     wave: 1,
     enemies: [],
     towers: [],


### PR DESCRIPTION
Adjusted `moveEnemyTowardTarget` to accept type: `Cell[]`

* Enemy de-spawns when no more cells are in it's path.
* Filtering enemies with valid paths to stay in `newGameState` while enemies' without have `sprite.destroy()` from memory.

Modified files:
`renderer.tsx`
`enemyMovement.ts`
`gameStateMachine.ts`
`type.ts`
`gameLogic.ts` (had to delete unfinished function for app to run)